### PR TITLE
fix: add `onValueChange` event handler inside `input-field-number` co…

### DIFF
--- a/components/common/forms/input-field-number.tsx
+++ b/components/common/forms/input-field-number.tsx
@@ -1,4 +1,4 @@
-import { NumberInput } from 'components/park-ui/number-input';
+import { NumberInput, NumberInputProps } from 'components/park-ui/number-input';
 
 import { FormLabel } from 'components/park-ui/form-label';
 import { Text } from 'components/park-ui/text';
@@ -16,10 +16,18 @@ type Props = {
 export const InputFieldNumber = ({ name, label, max, min }: Props) => {
   const [field, meta, helpers] = useField(name);
 
+  const onValueChange: NumberInputProps['onValueChange'] = (details) => {
+    const newValue = !Number.isNaN(details.valueAsNumber) ? details.valueAsNumber : undefined;
+
+    if (!Object.is(newValue, field.value)) {
+      helpers.setValue(newValue);
+    }
+  };
+
   return (
     <VStack gap={1} alignItems={'flex-start'}>
       <FormLabel htmlFor="name">{label}</FormLabel>
-      <NumberInput {...field} max={max} min={min} />
+      <NumberInput {...field} max={max} min={min} onValueChange={onValueChange} />
       {meta.touched && meta.error && <Text color="red">{meta.error}</Text>}
     </VStack>
   );


### PR DESCRIPTION
…mponent

Trying to fix https://github.com/rmrk-team/rmrk-composable-nft-creator/issues/11

This issue is because https://ark-ui.com/docs/components/number-input the component provide different API