### PR TITLE
style: optimize UI

### DIFF
--- a/components/catalog/parts-management/edit-part-equippable-whitelist/edit-part-equippable-whitelist.tsx
+++ b/components/catalog/parts-management/edit-part-equippable-whitelist/edit-part-equippable-whitelist.tsx
@@ -10,7 +10,9 @@ import {
   useWriteRmrkCatalogImplSetEquippableAddresses,
   useWriteRmrkCatalogImplSetEquippableToAll,
 } from 'lib/wagmi/generated';
+import { CheckCheck, Filter } from 'lucide-react';
 import React, { useState } from 'react';
+import { Flex } from 'styled-system/jsx';
 import { waitForTransactionReceipt } from 'wagmi/actions';
 
 type Props = {
@@ -125,15 +127,28 @@ export const EditPartEquippableWhitelist = ({
   }
 
   return (
-    <EditPartEquippableWhitelistModal
-      chainId={chainId}
-      catalogAddress={catalogAddress}
-      partId={partId}
-      onSubmit={onSubmit}
-      initialValues={initialValues}
-      onClose={onClose}
-      isOpen={isOpen}
-      setIsOpen={setIsOpen}
-    />
+    <Flex gap={2} direction={'column'} alignItems={'center'}>
+      <Flex gap={2} alignItems={'center'}>
+        {isEquippableToAll ? (
+          <>
+            <CheckCheck size={16} /> Public
+          </>
+        ) : (
+          <>
+            <Filter size={16} /> Whitelist
+          </>
+        )}
+      </Flex>
+      <EditPartEquippableWhitelistModal
+        chainId={chainId}
+        catalogAddress={catalogAddress}
+        partId={partId}
+        onSubmit={onSubmit}
+        initialValues={initialValues}
+        onClose={onClose}
+        isOpen={isOpen}
+        setIsOpen={setIsOpen}
+      />
+    </Flex>
   );
 };

--- a/components/catalog/parts-management/part-list-row.tsx
+++ b/components/catalog/parts-management/part-list-row.tsx
@@ -10,6 +10,8 @@ import type {
 } from 'abitype';
 import { EditPartEquippableWhitelist } from 'components/catalog/parts-management/edit-part-equippable-whitelist/edit-part-equippable-whitelist';
 import { Loader } from 'components/common/loader';
+import { Badge } from 'components/park-ui/badge';
+import { Text } from 'components/park-ui/text';
 import type { SupportedChainId } from 'lib/wagmi-config';
 import React from 'react';
 import { Box, Flex } from 'styled-system/jsx';
@@ -74,10 +76,18 @@ export const PartListRow = ({
         </Box>
       )}
 
-      <Box>id: {partId.toString()}</Box>
-      <Box>name: {metadata?.name}</Box>
-      <Box>zIndex: {part.z}</Box>
-      <Box>type: {partType}</Box>
+      <Flex direction={'column'} gap={2}>
+        <Flex alignItems={'center'} gap={2}>
+          <Badge variant={'solid'}>{partId.toString()}</Badge>
+          <Text size={'2xl'}>{metadata?.name}</Text>
+        </Flex>
+        <Flex gap={2}>
+          <Badge size={'sm'} variant={partType === 'slot' ? 'solid' : 'subtle'}>
+            type: {partType}
+          </Badge>
+          <Badge size={'sm'}>z-index: {part.z}</Badge>
+        </Flex>
+      </Flex>
 
       {partType === 'slot' && (
         <Box marginLeft={'auto'}>


### PR DESCRIPTION
The new UI will be displayd like below, and I've deployed this on vercel too, use this link instead: https://rmrk-composable-nft-creator-ten.vercel.app/

<img width="1035" alt="screenshot 2024-05-14" src="https://github.com/rmrk-team/rmrk-composable-nft-creator/assets/105423156/439656ae-eaf0-4227-a507-99aa1e4d82f5">
